### PR TITLE
Update PunchoutSerializer.cs

### DIFF
--- a/PunchoutSerializer.cs
+++ b/PunchoutSerializer.cs
@@ -4,6 +4,7 @@ using PunchoutUtils.Models;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
+using System.Globalization;
 using System.Web;
 
 namespace PunchoutUtils

--- a/PunchoutSerializer.cs
+++ b/PunchoutSerializer.cs
@@ -193,6 +193,11 @@ namespace PunchoutUtils
                     ?.GetCustomAttribute<EnumMemberAttribute>()?.Value ?? value.ToString();
             }
 
+            else if (type == typeof(float)) 
+            {
+                return ((float)value).ToString(CultureInfo.InvariantCulture);
+            }
+            
             else if (type == typeof(bool))
             {
                 return (bool)value ? "X" : null;
@@ -216,12 +221,12 @@ namespace PunchoutUtils
             else if (type == typeof(int))
             {
                 // We first parse to a float, so a value like 2.00 will still be recognized and cut off to 2
-                return (int)float.Parse(value);
+                return (int)float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
             }
 
             else if (type == typeof(float))
             {
-                return float.Parse(value);
+                return float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
             }
 
             else if (type == typeof(Uri))


### PR DESCRIPTION
This patch forces the use of a dot (.) for decimal points and a comma (,) for thousands. In some locals this would otherwise be reversed.